### PR TITLE
Fix alpha conversion in color utility

### DIFF
--- a/crates/gpui/src/color.rs
+++ b/crates/gpui/src/color.rs
@@ -27,9 +27,9 @@ pub(crate) fn swap_rgba_pa_to_bgra(color: &mut [u8]) {
     color.swap(0, 2);
     if color[3] > 0 {
         let a = color[3] as f32 / 255.;
-        color[0] = (color[0] as f32 / a) as u8;
-        color[1] = (color[1] as f32 / a) as u8;
-        color[2] = (color[2] as f32 / a) as u8;
+        color[0] = ((color[0] as f32 / a).min(255.0)) as u8;
+        color[1] = ((color[1] as f32 / a).min(255.0)) as u8;
+        color[2] = ((color[2] as f32 / a).min(255.0)) as u8;
     }
 }
 
@@ -333,7 +333,7 @@ pub const fn transparent_black() -> Hsla {
     }
 }
 
-/// Transparent black in [`Hsla`]
+/// Transparent white in [`Hsla`]
 pub const fn transparent_white() -> Hsla {
     Hsla {
         h: 0.,


### PR DESCRIPTION
## Summary
- clamp color channels when converting premultiplied RGBA
- fix documentation for `transparent_white`

## Testing
- `cargo +stable fmt --all` *(fails: `cargo-fmt` not installed)*
- `cargo +stable test -p gpui --tests --no-run` *(fails to fetch git dependencies)*
