### PR TITLE
Update README for TenderAI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Zed
+# TenderAI
 
 [![CI](https://github.com/zed-industries/zed/actions/workflows/ci.yml/badge.svg)](https://github.com/zed-industries/zed/actions/workflows/ci.yml)
 
-Welcome to Zed, a high-performance, multiplayer code editor from the creators of [Atom](https://github.com/atom/atom) and [Tree-sitter](https://github.com/tree-sitter/tree-sitter).
+Welcome to TenderAI, a high-performance, collaborative tender-writing application from the creators of [Atom](https://github.com/atom/atom) and [Tree-sitter](https://github.com/tree-sitter/tree-sitter).
 
 ---
 
@@ -12,23 +12,23 @@ Welcome to Zed, a high-performance, multiplayer code editor from the creators of
     <img src="https://repology.org/badge/vertical-allrepos/zed-editor.svg?minversion=0.143.5" alt="Packaging status" align="right">
 </a>
 
-On macOS and Linux you can [download Zed directly](https://zed.dev/download) or [install Zed via your local package manager](https://zed.dev/docs/linux#installing-via-a-package-manager).
+On macOS and Linux you can [download TenderAI directly](https://zed.dev/download) or [install TenderAI via your local package manager](https://zed.dev/docs/linux#installing-via-a-package-manager).
 
 Other platforms are not yet available:
 
 - Windows ([tracking issue](https://github.com/zed-industries/zed/issues/5394))
 - Web ([tracking issue](https://github.com/zed-industries/zed/issues/5396))
 
-### Developing Zed
+### Developing TenderAI
 
-- [Building Zed for macOS](./docs/src/development/macos.md)
-- [Building Zed for Linux](./docs/src/development/linux.md)
-- [Building Zed for Windows](./docs/src/development/windows.md)
+- [Building TenderAI for macOS](./docs/src/development/macos.md)
+- [Building TenderAI for Linux](./docs/src/development/linux.md)
+- [Building TenderAI for Windows](./docs/src/development/windows.md)
 - [Running Collaboration Locally](./docs/src/development/local-collaboration.md)
 
 ### Contributing
 
-See [CONTRIBUTING.md](./CONTRIBUTING.md) for ways you can contribute to Zed.
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for ways you can contribute to TenderAI.
 
 Also... we're hiring! Check out our [jobs](https://zed.dev/jobs) page for open roles.
 


### PR DESCRIPTION
## Summary
- rename references to Zed as TenderAI
- describe the app as a tender-writing application

## Testing
- `git status --short`