### PR TITLE
Document offline Rust toolchain mirror

### DIFF
--- a/docs/src/development/linux.md
+++ b/docs/src/development/linux.md
@@ -14,6 +14,11 @@ Clone down the [Zed repository](https://github.com/zed-industries/zed).
   script/linux
   ```
 
+  If your environment restricts external network access, configure
+  `RUSTUP_INIT_URL` and `RUSTUP_DIST_SERVER` to point to your internal
+  mirror before running the script. This allows the Rust toolchain to be
+  installed without contacting the public servers.
+
   If you prefer to install the system libraries manually, you can find the list of required packages in the `script/linux` file.
 
 ## Backend dependencies

--- a/docs/src/development/macos.md
+++ b/docs/src/development/macos.md
@@ -7,6 +7,8 @@ Clone down the [Zed repository](https://github.com/zed-industries/zed).
 ## Dependencies
 
 - Install [rustup](https://www.rust-lang.org/tools/install)
+  (or use a cached mirror by setting `RUSTUP_INIT_URL` and
+  `RUSTUP_DIST_SERVER` before running `script/bootstrap`)
 
 - Install [Xcode](https://apps.apple.com/us/app/xcode/id497799835?mt=12) from the macOS App Store, or from the [Apple Developer](https://developer.apple.com/download/all/) website. Note this requires a developer account.
 

--- a/docs/src/development/windows.md
+++ b/docs/src/development/windows.md
@@ -9,6 +9,8 @@ Clone down the [Zed repository](https://github.com/zed-industries/zed).
 ## Dependencies
 
 - Install [rustup](https://www.rust-lang.org/tools/install)
+  (set `RUSTUP_INIT_URL` and `RUSTUP_DIST_SERVER` to use an internal
+  mirror when external network access is restricted)
 
 - Install [Visual Studio](https://visualstudio.microsoft.com/downloads/) with the optional components `MSVC v*** - VS YYYY C++ x64/x86 build tools` and `MSVC v*** - VS YYYY C++ x64/x86 Spectre-mitigated libs (latest)` (`v***` is your VS version and `YYYY` is year when your VS was released. Pay attention to the architecture and change it to yours if needed.)
 - Install Windows 11 or 10 SDK depending on your system, but ensure that at least `Windows 10 SDK version 2104 (10.0.20348.0)` is installed on your machine. You can download it from the [Windows SDK Archive](https://developer.microsoft.com/windows/downloads/windows-sdk/)

--- a/script/linux
+++ b/script/linux
@@ -10,7 +10,19 @@ fi
 
 function finalize {
   # after packages install (curl, etc), get the rust toolchain
-  which rustup > /dev/null 2>&1 || curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+  if ! command -v rustup >/dev/null 2>&1; then
+    init_url="${RUSTUP_INIT_URL:-https://sh.rustup.rs}"
+    curl --proto '=https' --tlsv1.2 -sSf "$init_url" | sh -s -- -y
+  fi
+  if [[ -n "${RUSTUP_DIST_SERVER:-}" ]]; then
+    export RUSTUP_DIST_SERVER
+    export RUSTUP_UPDATE_ROOT="$RUSTUP_DIST_SERVER"
+  fi
+  toolchain="$(grep -Po '(?<=channel = ")([^"]*)' rust-toolchain.toml)"
+  if ! rustup toolchain list | grep -q "$toolchain"; then
+    rustup toolchain install "$toolchain" \
+      --profile minimal --component rustfmt,clippy
+  fi
   # verify the mold situation
   if ! command -v mold >/dev/null 2>&1; then
     echo "Warning: Mold binaries are unavailable on your system." >&2


### PR DESCRIPTION
## Summary
- mention RUSTUP_INIT_URL and RUSTUP_DIST_SERVER in platform docs
- support mirror install in `script/linux`

## Testing
- `cargo nextest run --workspace --no-fail-fast` *(fails: no such command `nextest`)*
- `cargo fmt --all -- --check` *(fails: `cargo-fmt` not installed)*