### PR TITLE
Add Windows installer scripts

### DIFF
--- a/docs/src/windows.md
+++ b/docs/src/windows.md
@@ -1,14 +1,36 @@
 # Zed on Windows
 
-Zed is not supported on Windows (yet). We have limited developer bandwidth, and a
-new platform is a large undertaking. However, the community has developed
-a build of Zed on Windows, and you can compile it yourself with these instructions:
+Zed now has experimental Windows builds. They can be installed using our PowerShell script.
 
-- [Building for Windows](./development/windows.md)
+## Installing
 
-We are currently hiring a [Windows Lead](https://zed.dev/jobs/windows-lead).
+Run the following command from a PowerShell prompt:
 
-For now, we welcome contributions from the community to improve Windows support.
+```powershell
+irm https://zed.dev/install.ps1 | iex
+```
 
-- [GitHub Issues with 'Windows' label](https://github.com/zed-industries/zed/issues?q=is%3Aissue+is%3Aopen+label%3Awindows)
-- [Zed Community Discord](https://zed.dev/community-links) -> `#windows`
+Set the `ZED_CHANNEL` environment variable to `preview` to install preview builds:
+
+```powershell
+$env:ZED_CHANNEL = 'preview'
+irm https://zed.dev/install.ps1 | iex
+```
+
+The script downloads the latest bundle, extracts it to `%LOCALAPPDATA%\Programs\Zed`, creates a Start Menu shortcut, and registers the `.zed` file association.
+
+## Uninstalling
+
+To remove Zed installed by the script, run:
+
+```powershell
+irm https://zed.dev/uninstall.ps1 | iex
+```
+
+Alternatively, you can run `script/uninstall.ps1` from a cloned repository.
+
+## Building from source
+
+If you wish to build Zed yourself or contribute to Windows support, see [Building for Windows](./development/windows.md).
+
+We are currently hiring a [Windows Lead](https://zed.dev/jobs/windows-lead) and welcome contributions from the community. Join the discussion in the [Windows issues list](https://github.com/zed-industries/zed/issues?q=is%3Aissue+is%3Aopen+label%3Awindows) or on our [Zed Community Discord](https://zed.dev/community-links) in the `#windows` channel.

--- a/script/install.ps1
+++ b/script/install.ps1
@@ -1,0 +1,41 @@
+$ErrorActionPreference = 'Stop'
+$PSNativeCommandUseErrorActionPreference = $true
+
+param(
+    [string]$Channel = $env:ZED_CHANNEL
+)
+
+if (-not $Channel) { $Channel = 'stable' }
+
+$arch = if ($env:PROCESSOR_ARCHITECTURE -eq 'ARM64') { 'aarch64' } else { 'x86_64' }
+$tmp    = New-Item -ItemType Directory -Path ([System.IO.Path]::GetTempPath()) -Name ("zed-" + [System.Guid]::NewGuid().ToString())
+$bundle = Join-Path $tmp "zed-windows-$arch.zip"
+$uri    = "https://zed.dev/api/releases/$Channel/latest/zed-windows-$arch.zip"
+
+Write-Output "Downloading Zed..."
+Invoke-WebRequest -Uri $uri -OutFile $bundle -UseBasicParsing
+
+$installDir = Join-Path $env:LOCALAPPDATA 'Programs\Zed'
+if (Test-Path $installDir) { Remove-Item $installDir -Recurse -Force }
+Expand-Archive -Path $bundle -DestinationPath $installDir -Force
+
+$startMenuDir = Join-Path $env:APPDATA 'Microsoft\Windows\Start Menu\Programs'
+$shortcutPath = Join-Path $startMenuDir 'Zed.lnk'
+$wsh = New-Object -ComObject WScript.Shell
+$sc = $wsh.CreateShortcut($shortcutPath)
+$sc.TargetPath = Join-Path $installDir 'Zed.exe'
+$sc.IconLocation = Join-Path $installDir 'Zed.exe'
+$sc.WorkingDirectory = $installDir
+$sc.Save()
+
+# File association for .zed files
+$progIdPath = 'HKCU:\Software\Classes\Zed.File'
+New-Item -Path $progIdPath -Force | Out-Null
+Set-ItemProperty -Path $progIdPath -Name '(Default)' -Value 'Zed File' | Out-Null
+New-Item -Path "$progIdPath\shell\open\command" -Force | Out-Null
+$cli = Join-Path $installDir 'bin\zed.exe'
+Set-ItemProperty -Path "$progIdPath\shell\open\command" -Name '(Default)' -Value "`"$cli`" `"%1`"" | Out-Null
+New-Item -Path 'HKCU:\Software\Classes\.zed' -Force | Out-Null
+Set-ItemProperty -Path 'HKCU:\Software\Classes\.zed' -Name '(Default)' -Value 'Zed.File' | Out-Null
+
+Write-Output "Zed installed to $installDir"

--- a/script/uninstall.ps1
+++ b/script/uninstall.ps1
@@ -1,0 +1,18 @@
+$ErrorActionPreference = 'Stop'
+$PSNativeCommandUseErrorActionPreference = $true
+
+$installDir = Join-Path $env:LOCALAPPDATA 'Programs\Zed'
+$shortcutPath = Join-Path $env:APPDATA 'Microsoft\Windows\Start Menu\Programs\Zed.lnk'
+
+if (Test-Path $installDir) {
+    Remove-Item $installDir -Recurse -Force
+}
+
+if (Test-Path $shortcutPath) {
+    Remove-Item $shortcutPath -Force
+}
+
+Remove-Item -Path 'HKCU:\Software\Classes\.zed' -Recurse -Force -ErrorAction SilentlyContinue
+Remove-Item -Path 'HKCU:\Software\Classes\Zed.File' -Recurse -Force -ErrorAction SilentlyContinue
+
+Write-Output 'Zed has been uninstalled.'


### PR DESCRIPTION
## Summary
- add `script/install.ps1` to install Windows builds
- add `script/uninstall.ps1` to clean up the install
- document Windows script usage in docs

## Testing
- `cargo fmt --all -- --check` *(fails: could not download Rust toolchain)*